### PR TITLE
pass through requestOptions to httpreq

### DIFF
--- a/httpntlm.js
+++ b/httpntlm.js
@@ -1,3 +1,4 @@
+var extend = require('node.extend');
 var async = require('async');
 var url = require('url');
 var httpreq = require('httpreq');
@@ -42,15 +43,17 @@ exports.method = function(method, options, callback){
 
 			var type2msg = ntlm.parseType2Message(res.headers['www-authenticate']);
 			var type3msg = ntlm.createType3Message(type2msg, options);
-
-			httpreq[method](options.url, {
+			var requestOptions = (typeof options['requestOptions'] === 'object') ? options.requestOptions : {};
+			var mergedOptions = extend(true, {
 				headers:{
 					'Connection' : 'Close',
 					'Authorization': type3msg
 				},
 				allowRedirects: false,
 				agent: keepaliveAgent
-			}, $);
+			}, requestOptions);
+
+			httpreq[method](options.url, mergedOptions, $);
 		}
 	], callback);
 };

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "dependencies": {
     "httpreq": "~0.3.4",
     "async": "~0.2.9",
-    "agentkeepalive": "~0.1.5"
+    "agentkeepalive": "~0.1.5",
+    "node.extend": "~1.0.7"
   },
   "author": {
     "name": "Sam Decrock",


### PR DESCRIPTION
I found that I couldn't pass additional headers or a post body.  This tweak lets users specify any param supported by httpreq 'requestOptions'.  'requestOptions' is then deep copies on top of the base object.
