### PR TITLE
Binary downloads and timeout as options

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,4 @@
+{
+  "node": true,
+  "laxbreak": true
+}

--- a/README.md
+++ b/README.md
@@ -31,6 +31,18 @@ httpntlm.get({
 
 Should support __http__ and __https__ now. Though, I've not tested it on http.
 
+## Options
+
+- `url:`      _{String}_   URL to connect. (Required)
+- `username:` _{String}_   Username. (Required)
+- `password:` _{String}_   Password. (Required)
+- `workstation:` _{String}_ Name of workstation or `''`.
+- `domain:`   _{String}_   Name of domain or `''`.
+- `body:`     _{String}_   Custom body.
+- `headers:`  _{Object}_   Custom headers.
+- `binary:`   _{Boolean}_  If `true` returns a Buffer instead of a String (Default: `false`).
+- `timeout:`  _{Number}_   Connection timeout in milliseconds (Default: `0` == waits till doomsday).
+
 ## Advanced
 
 If you want to use the NTLM-functions yourself, you can access the ntlm-library like this (https example):
@@ -86,6 +98,7 @@ async.waterfall([
     console.log(res.body);
 });
 ```
+
 ## More information
 
 * [python-ntlm](https://code.google.com/p/python-ntlm/)

--- a/httpntlm.js
+++ b/httpntlm.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var async = require('async');
 var url = require('url');
 var httpreq = require('httpreq');
@@ -32,6 +34,7 @@ exports.method = function(method, options, callback){
 					'Connection' : 'keep-alive',
 					'Authorization': type1msg
 				},
+				timeout: options.timeout || 0,
 				agent: keepaliveAgent
 			}, $);
 		},
@@ -45,21 +48,23 @@ exports.method = function(method, options, callback){
 			var headers = options.headers || {}; 
 			var body = options.body || '';
 
-			headers['Connection'] = 'Close';
-			headers['Authorization'] = type3msg;
+			headers.Connection = 'Close';
+			headers.Authorization = type3msg;
 
 			httpreq[method](options.url, {
 				headers: headers,
 				allowRedirects: false,
 				agent: keepaliveAgent,
-				body: body
+				body: body,
+				timeout: options.timeout || 0,
+				binary: options.binary || false
 			}, $);
 		}
 	], callback);
 };
 
 ['get', 'put', 'post', 'delete', 'head'].forEach(function(method){
-  exports[method] = exports.method.bind(exports, method);
+	exports[method] = exports.method.bind(exports, method);
 });
 
 exports.ntlm = ntlm; //if you want to use the NTML functions yourself

--- a/ntlm.js
+++ b/ntlm.js
@@ -33,7 +33,7 @@ var flags = {
 	NTLM_Negotiate128                    :  0x20000000,
 	NTLM_NegotiateKeyExchange            :  0x40000000,
 	NTLM_Negotiate56                     :  0x80000000
-}
+};
 var typeflags = {
 	NTLM_TYPE1_FLAGS : 	  flags.NTLM_NegotiateUnicode
 						+ flags.NTLM_NegotiateOEM
@@ -56,7 +56,7 @@ var typeflags = {
 						+ flags.NTLM_NegotiateVersion
 						+ flags.NTLM_Negotiate128
 						+ flags.NTLM_Negotiate56
-}
+};
 
 function createType1Message(options){
 	var domain = escape(options.domain.toUpperCase());
@@ -66,7 +66,7 @@ function createType1Message(options){
 	var BODY_LENGTH = 40;
 
 	var type1flags = typeflags.NTLM_TYPE1_FLAGS;
-	if(!domain || domain == '')
+	if(!domain || domain === '')
 		type1flags = type1flags - flags.NTLM_NegotiateOemDomainSupplied;
 
 	var pos = 0;
@@ -231,7 +231,7 @@ function createType3Message(msg2, options){
 
 function create_LM_hashed_password_v1(password){
 	// fix the password length to 14 bytes
-	var password = password.toUpperCase();
+	password = password.toUpperCase();
 	var passwordBytes = new Buffer(password, 'ascii');
 
 	var passwordBytesPadded = new Buffer(14);
@@ -262,7 +262,7 @@ function insertZerosEvery7Bits(buf){
 	for(var i=0; i<binaryArray.length; i++){
 		newBinaryArray.push(binaryArray[i]);
 
-		if((i+1)%7 == 0){
+		if((i+1)%7 === 0){
 			newBinaryArray.push(0);
 		}
 	}
@@ -316,7 +316,7 @@ function binaryArray2bytes(array){
 		'1101': 'D',
 		'1110': 'E',
 		'1111': 'F'
-	}
+	};
 
  	var bufArray = [];
 
@@ -354,10 +354,10 @@ function calc_resp(password_hash, server_challenge){
     var des = crypto.createCipheriv('DES-ECB', insertZerosEvery7Bits(passHashPadded.slice(0,7)), '');
     resArray.push( des.update(server_challenge.slice(0,8)) );
 
-    var des = crypto.createCipheriv('DES-ECB', insertZerosEvery7Bits(passHashPadded.slice(7,14)), '');
+    des = crypto.createCipheriv('DES-ECB', insertZerosEvery7Bits(passHashPadded.slice(7,14)), '');
     resArray.push( des.update(server_challenge.slice(0,8)) );
 
-    var des = crypto.createCipheriv('DES-ECB', insertZerosEvery7Bits(passHashPadded.slice(14,21)), '');
+    des = crypto.createCipheriv('DES-ECB', insertZerosEvery7Bits(passHashPadded.slice(14,21)), '');
     resArray.push( des.update(server_challenge.slice(0,8)) );
 
    	return Buffer.concat(resArray);
@@ -378,7 +378,7 @@ function ntlm2sr_calc_resp(responseKeyNT, serverChallenge, clientChallenge){
     return {
     	lmChallengeResponse: lmChallengeResponse,
     	ntChallengeResponse: ntChallengeResponse
-    }
+    };
 }
 
 exports.createType1Message = createType1Message;

--- a/package.json
+++ b/package.json
@@ -37,5 +37,8 @@
       "type": "MIT",
       "url": "http://www.opensource.org/licenses/mit-license.php"
     }
-  ]
+  ],
+  "scripts": {
+    "jshint": "jshint *.js"
+  }
 }


### PR DESCRIPTION
This PR adds the following options to httpntlm.js:
- `binary: true` (Default is false)
  - Download of binary URIs. httpreq offers back a buffer instead of a string. 
- `timeout: <ms>`: Adds a custom timeout (in milliseconds) to the http(s) request.
  - `err` will be `{ [Error: request timed out] code: 'TIMEOUT' }` in case that timeout is shorter than the server response. Default is 0 which waits until doomsday.

P.S: Did some jshint stuff - so there should be some extra `;` and some less `var`'s
