### PR TITLE
Use core http(s) Agent instead of agentkeepalive module

### DIFF
--- a/httpntlm.js
+++ b/httpntlm.js
@@ -5,6 +5,8 @@ var url = require('url');
 var httpreq = require('httpreq');
 var ntlm = require('./ntlm');
 var _ = require('underscore');
+var http = require('http');
+var https = require('https');
 
 exports.method = function(method, options, callback){
 	if(!options.workstation) options.workstation = '';
@@ -22,11 +24,9 @@ exports.method = function(method, options, callback){
 	var keepaliveAgent;
 
 	if(isHttps){
-		var HttpsAgent = require('agentkeepalive').HttpsAgent;
-		keepaliveAgent = new HttpsAgent();
+		keepaliveAgent = new https.Agent({keepAlive: true});
 	}else{
-		var Agent = require('agentkeepalive');
-		keepaliveAgent = new Agent();
+		keepaliveAgent = new http.Agent({keepAlive: true});
 	}
 
 	async.waterfall([

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "description": "httpntlm is a Node.js library to do HTTP NTLM authentication",
   "version": "1.5.2",
   "dependencies": {
-    "agentkeepalive": ">=1.2.0",
     "async": "~0.2.9",
     "httpreq": ">=0.4.5",
     "underscore": "~1.7.0"


### PR DESCRIPTION
We're using this module to send requests against a pretty slow interface. We were seeing sockets closed for no apparent reason at the 1 minute mark, resulting in ECONNRESET errors. I eventually traced the problem to the agentkeepalive module. Using the core http Agent instead resolved the issue for me.

I realize there may be reasons beyond what I've noticed that agentkeepalive is used here, but for my use case the core module makes more sense, so I thought I would propose this. We are running iojs 2.x.x, but I believe these changes should be acceptable for Node as well.