### PR TITLE
pass along options to type1options

### DIFF
--- a/httpntlm.js
+++ b/httpntlm.js
@@ -43,9 +43,9 @@ exports.method = function(method, options, callback){
 				agent: keepaliveAgent
 			};
 
-			// pass along other options:
-			type1options.headers = _.extend(type1options.headers, httpreqOptions.headers);
-			type1options = _.extend(type1options, _.omit(httpreqOptions, 'headers'));
+			// pass along timeout and ca:
+			if(httpreqOptions.timeout) type1options.timeout = httpreqOptions.timeout;
+			if(httpreqOptions.ca) type1options.ca = httpreqOptions.ca;
 
 			// send type1 message to server:
 			httpreq.get(options.url, type1options, $);

--- a/httpntlm.js
+++ b/httpntlm.js
@@ -43,8 +43,9 @@ exports.method = function(method, options, callback){
 				agent: keepaliveAgent
 			};
 
-			// add timeout option:
-			if(httpreqOptions.timeout) type1options.timeout = httpreqOptions.timeout;
+			// pass along other options:
+			type1options.headers = _.extend(type1options.headers, httpreqOptions.headers);
+			type1options = _.extend(type1options, _.omit(httpreqOptions, 'headers'));
 
 			// send type1 message to server:
 			httpreq.get(options.url, type1options, $);


### PR DESCRIPTION
The same was being done in the type3options. Code was copied from there.

In my case I needed ca (certificate authorities) and allowRedirects to be applied to type1options.