### PR TITLE
Pass along all options (fix for issue #61)

### DIFF
--- a/httpntlm.js
+++ b/httpntlm.js
@@ -51,9 +51,9 @@ exports.method = function(method, options, finalCallback){
 			allowRedirects: false // don't redirect in httpreq, because http could change to https which means we need to change the keepaliveAgent
 		};
 
-		// pass along timeout and ca:
-		if(httpreqOptions.timeout) type1options.timeout = httpreqOptions.timeout;
-		if(httpreqOptions.ca) type1options.ca = httpreqOptions.ca;
+		// pass along other options:
+		type1options.headers = _.extend({}, httpreqOptions.headers, type1options.headers);
+		type1options = _.extend({}, _.omit(httpreqOptions, 'headers'), type1options);
 
 		// send type1 message to server:
 		httpreq.get(options.url, type1options, callback);

--- a/httpntlm.js
+++ b/httpntlm.js
@@ -52,8 +52,7 @@ exports.method = function(method, options, finalCallback){
 		};
 
 		// pass along other options:
-		type1options.headers = _.extend({}, httpreqOptions.headers, type1options.headers);
-		type1options = _.extend({}, _.omit(httpreqOptions, 'headers'), type1options);
+		type1options = _.extend({}, _.omit(httpreqOptions, 'headers', 'body'), type1options);
 
 		// send type1 message to server:
 		httpreq.get(options.url, type1options, callback);


### PR DESCRIPTION
Fix for #61 
This change allows the user to pass other options to httpreq. For instance a proxy configuration:
```js
httpntlm.get({
    url: "https://someurl.com",
    username: 'm$',
    password: 'stinks',
    workstation: 'choose.something',
    proxy: {
        host: 'proxy.local.com',
        port: 8080
    }
}, function (err, res){
    if(err) return err;

    console.log(res.headers);
    console.log(res.body);
});
```