### PR TITLE
Add new "binary" option to support downloading binary files.

### DIFF
--- a/httpntlm.js
+++ b/httpntlm.js
@@ -20,7 +20,7 @@ exports.method = function(method, options, finalCallback){
 	if(!options.domain) options.domain = '';
 
 	// extract non-ntlm-options:
-	var httpreqOptions = _.omit(options, 'url', 'username', 'password', 'workstation', 'domain');
+	var httpreqOptions = _.omit(options, 'url', 'username', 'password', 'workstation', 'domain', 'binary');
 
 	// is https?
 	var isHttps = false;
@@ -48,7 +48,8 @@ exports.method = function(method, options, finalCallback){
 			},
 			timeout: options.timeout || 0,
 			agent: keepaliveAgent,
-			allowRedirects: false // don't redirect in httpreq, because http could change to https which means we need to change the keepaliveAgent
+			allowRedirects: false, // don't redirect in httpreq, because http could change to https which means we need to change the keepaliveAgent
+			binary: options.binary || false
 		};
 
 		// pass along other options:
@@ -83,7 +84,8 @@ exports.method = function(method, options, finalCallback){
 				'Authorization': type3msg
 			},
 			allowRedirects: false,
-			agent: keepaliveAgent
+			agent: keepaliveAgent,
+			binary: options.binary || false
 		};
 
 		// pass along other options:


### PR DESCRIPTION
The httpreq library will not properly download binary files without using the "binary" option. This change adds an option to httpntlm that gets passed through to httpreq. It's false by default.

I've verified that this works on my own installation, downloading an image from a server.