### PR TITLE
sendType1Message should use the provided method (GET/POST ...)

### DIFF
--- a/httpntlm.js
+++ b/httpntlm.js
@@ -55,7 +55,7 @@ exports.method = function(method, options, finalCallback){
 		type1options = _.extend({}, _.omit(httpreqOptions, 'headers', 'body'), type1options);
 
 		// send type1 message to server:
-		httpreq.get(options.url, type1options, callback);
+		httpreq[method](options.url, type1options, callback);
 	}
 
 	function sendType3Message (res, callback) {


### PR DESCRIPTION
I tried to authenticate against a [QlikView Management Service (QMS) API](http://help.qlik.com/en-US/qlikview-developer/November2017/Content/APIsAndSDKs.htm) which uses SOAP with NTLM. Without passing the HTTP method to the service, the service delivers the WSDL without NTLM which leads to the error "www-authenticate not found on response of second request". Passing the "POST" method fixes this error. I guess it is standard behaviour, so I request this "bugfix".