### PR TITLE
Update underscore to latest minor version

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.7.5",
   "dependencies": {
     "httpreq": ">=0.4.22",
-    "underscore": "~1.7.0"
+    "underscore": "~1.8.0"
   },
   "author": {
     "name": "Sam Decrock",


### PR DESCRIPTION
It's been out for nearly three years and `1.7.0` has an [issue](https://github.com/jashkenas/underscore/commit/b17bd671ca49e1b76b43f29cee40352fb4651c9f) with `_.extend`