### PR TITLE
update underscore to fix CVE-2021-23358

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.7.6",
   "dependencies": {
     "httpreq": ">=0.4.22",
-    "underscore": "~1.7.0"
+    "underscore": "~1.12.1"
   },
   "author": {
     "name": "Sam Decrock",


### PR DESCRIPTION
Current version of underscore used has a security vulnerability:

https://nvd.nist.gov/vuln/detail/CVE-2021-23358

This one has a rating of 9.8/10 (CRITICAL) currently at NIST/MITRE and should be fixed asap

As your package depends on the 1.7.x bugfix versions it does not pickup latest secure versions of it own.

This PR supersedes #74.