### PR TITLE
In ntlm.js conversion of literal values ​​to BigInt is added

### DIFF
--- a/ntlm.js
+++ b/ntlm.js
@@ -424,7 +424,7 @@ function calc_ntlmv2_resp(pwhash, username, domain, targetInfo, serverChallenge,
 
 	// 11644473600000 = diff between 1970 and 1601
 	var now = Date.now();
-	var timestamp = ((BigInt(now) + 11644473600000n) * 10000n);
+	var timestamp = ((BigInt(now) + BigInt(11644473600000)) * BigInt(10000));
 	var timestampBuffer = Buffer.alloc(8);
 	timestampBuffer.writeBigUInt64LE(timestamp);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,54 @@
+{
+  "name": "httpntlm",
+  "version": "1.8.1",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "httpntlm",
+      "version": "1.8.1",
+      "funding": [
+        {
+          "type": "paypal",
+          "url": "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=LPYD83FGC7XPW"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/samdecrock"
+        }
+      ],
+      "dependencies": {
+        "httpreq": ">=0.4.22",
+        "underscore": "~1.12.1"
+      },
+      "engines": {
+        "node": ">=10.4.0"
+      }
+    },
+    "node_modules/httpreq": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/httpreq/-/httpreq-0.5.2.tgz",
+      "integrity": "sha512-2Jm+x9WkExDOeFRrdBCBSpLPT5SokTcRHkunV3pjKmX/cx6av8zQ0WtHUMDrYb6O4hBFzNU6sxJEypvRUVYKnw==",
+      "engines": {
+        "node": ">= 6.15.1"
+      }
+    },
+    "node_modules/underscore": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
+      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
+    }
+  },
+  "dependencies": {
+    "httpreq": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/httpreq/-/httpreq-0.5.2.tgz",
+      "integrity": "sha512-2Jm+x9WkExDOeFRrdBCBSpLPT5SokTcRHkunV3pjKmX/cx6av8zQ0WtHUMDrYb6O4hBFzNU6sxJEypvRUVYKnw=="
+    },
+    "underscore": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
+      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "httpntlm",
   "description": "httpntlm is a Node.js library to do HTTP NTLM authentication",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "dependencies": {
     "httpreq": ">=0.4.22",
     "underscore": "~1.12.1"


### PR DESCRIPTION
Since we can't know which module uses this dependency, or at least we can't constantly check, I think it's better to code-protect by casting a literal value to BigInt.
As in the example.

	// 11644473600000 = diff between 1970 and 1601
	var now = Date.now();
	var timestamp = ((BigInt(now) + BigInt(11644473600000)) * BigInt(10000));

PD: Sorry for my bad English.