### PR TITLE
Updated ntlm.js, replacing xxxn with BigInt

### DIFF
--- a/ntlm.js
+++ b/ntlm.js
@@ -424,7 +424,7 @@ function calc_ntlmv2_resp(pwhash, username, domain, targetInfo, serverChallenge,
 
 	// 11644473600000 = diff between 1970 and 1601
 	var now = Date.now();
-	var timestamp = ((BigInt(now) + 11644473600000n) * 10000n);
+	var timestamp = ((BigInt(now) + BigInt(11644473600000)) * BigInt(10000));
 	var timestampBuffer = Buffer.alloc(8);
 	timestampBuffer.writeBigUInt64LE(timestamp);
 


### PR DESCRIPTION
Using BigInt(x) instead if xxxn, though the current one is correct, but it is throwing exceptions in some old versions, for example node soap. like "Invalid or unexpected token". Using BigInt(x) will work with older node versions too.